### PR TITLE
Check proto versio

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,31 @@ Regardless of chosen library we are required to have configured a Tuya Cloud pro
 ## Using pymoebot
 > **_NOTE:_**  The MoeBot needs to have been activated by adding it to the Tuya/SmartLife app first.
 
-In it's most simplistic use, get an instance of `MoeBot` and query its status.
+In it's most simplistic use, get an instance of `MoeBot`, poll for data and then show its attributes.
 
 ```python
 from pymoebot import MoeBot
 
 moebot = MoeBot('DEVICE_ID', 'IP', 'LOCAL_KEY')
+moebot.poll()
 print("Battery level: %s%" % moebot.battery)
 ```
 
-See the [examples](https://github.com/Whytey/pymoebot/tree/main/examples) for full examples of usage.
+Alternatively, register as a listener and then start the listening thread on your `MoeBot`.
+
+```python
+from pymoebot import MoeBot
+
+moebot = MoeBot('DEVICE_ID', 'IP', 'LOCAL_KEY')
+moebot.add_listener(lambda d: print("Got data: %s", d))
+moebot.listen()
+
+# Do some other stuff
+
+moebot.unlisten()
+```
+
+See the [examples](https://github.com/Whytey/pymoebot/tree/main/examples) for further examples of usage.
 
 # Communicating with the MoeBot
 

--- a/examples/sniffer/README.md
+++ b/examples/sniffer/README.md
@@ -1,3 +1,7 @@
 # sniffer.py
 
-Dumps all relevant messages from the TuyaOpenMQ that are associated with a MoeBot. 
+Dumps all relevant messages from the `TuyaOpenMQ` that are associated with a MoeBot. 
+
+First, add you config to `default.ini` or create a new config file using the same format.
+
+Call `python sniffer.ini`

--- a/examples/sniffer/sniffer.py
+++ b/examples/sniffer/sniffer.py
@@ -13,7 +13,7 @@ def read_config(filename=None):
     if filename:
         if os.path.exists(filename):
             logging.debug("Reading extra config from '%s'", filename)
-            config.read('sniffer.ini')
+            config.read(filename)
         else:
             logging.warning("config file '%s' doesn't exist, ignoring.", filename)
 
@@ -37,6 +37,11 @@ def main():
     logging.info("Got a MoeBot: %s" % moebot)
 
     moebot.add_listener(listener)
+
+    try:
+        moebot.listen()
+    except KeyboardInterrupt:
+        moebot.unlisten()
 
 
 if __name__ == "__main__":

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -1,7 +1,27 @@
 import unittest
+from unittest import mock
+
 from pymoebot import MoeBotConnectionError, MoeBot
 
+
 class TestMoeBot(unittest.TestCase):
-    def test_no_device(self):
-        self.assertRaises(MoeBotConnectionError, MoeBot, "RANDOM", "127.0.0.1", "RANDOM_KEY_ABCDE")
-        
+    @mock.patch('tinytuya.Device.status')
+    def test_no_device(self, mock_status):
+        mock_status.return_value = {'Error': 'Network Error: Device Unreachable', 'Err': '905', 'Payload': None}
+
+        m = MoeBot("RANDOM", "127.0.0.1", "RANDOM_KEY_ABCDE")
+        self.assertFalse(m.online)
+        self.assertIsNone(m.state)
+
+    @mock.patch('tinytuya.Device.status')
+    def test_mock_device(self, mock_status):
+        mock_status.return_value = {
+            'dps': {'6': 100, '101': 'STANDBY', '102': 0, '103': 'MOWER_LEAN', '104': True, '105': 3, '106': 1111,
+                    '114': 'AutoMode'}}
+
+        m = MoeBot("RANDOM", "127.0.0.1", "RANDOM_KEY_ABCDE")
+        self.assertFalse(m.online)
+        self.assertIsNone(m.state)
+        m.poll()
+        self.assertTrue(m.online)
+        self.assertIsNotNone(m.state)

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -3,5 +3,5 @@ from pymoebot import MoeBotConnectionError, MoeBot
 
 class TestMoeBot(unittest.TestCase):
     def test_no_device(self):
-        self.assertRaises(MoeBotConnectionError, MoeBot("RANDOM", "127.0.0.1", "RANDOM_KEY_ABCDE"))
+        self.assertRaises(MoeBotConnectionError, MoeBot, "RANDOM", "127.0.0.1", "RANDOM_KEY_ABCDE")
         


### PR DESCRIPTION
- Added the ability to work with MoeBots using different Tuya protocol versions; 3.3 and 3.4 (only known occurrences so far).
- Implementer is now able to decide if we have a persistent connection to the MoeBot (through the `listen()`/unlisten()` methods) or just a simple connection.
- Expose a couple more attributes: online and tuya_version